### PR TITLE
Implement DeriveEcdh command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ Currently the following commands are implemented:
  * SignDataEddsa
  * PutAsymmetricKey
  * GetPubKey
+ * DeriveEcdh
  * Echo
  * Authentication & Session related commands
- 
+
 Implementing new commands is really easy. Please consult `commands/constructors.go` and `commands/response.go` for reference.
 
 Please submit a PR if you have implemented new commands or extended existing constructors.

--- a/commands/constructors.go
+++ b/commands/constructors.go
@@ -205,3 +205,16 @@ func CreateEchoCommand(data []byte) (*CommandMessage, error) {
 
 	return command, nil
 }
+
+func CreateDeriveEcdhCommand(objID uint16, pubkey []byte) (*CommandMessage, error) {
+	command := &CommandMessage{
+		CommandType: CommandTypeDeriveEcdh,
+	}
+
+	payload := bytes.NewBuffer([]byte{})
+	binary.Write(payload, binary.BigEndian, objID)
+	payload.Write(pubkey)
+	command.Data = payload.Bytes()
+
+	return command, nil
+}

--- a/commands/response.go
+++ b/commands/response.go
@@ -75,6 +75,10 @@ type (
 	EchoResponse struct {
 		Data []byte
 	}
+
+	DeriveEcdhResponse struct {
+		XCoordinate []byte
+	}
 )
 
 // ParseResponse parses the binary response from the card to the relevant Response type.
@@ -125,6 +129,8 @@ func ParseResponse(data []byte) (Response, error) {
 		return nil, nil
 	case CommandTypeEcho:
 		return parseEchoResponse(payload)
+	case CommandTypeDeriveEcdh:
+		return parseDeriveEcdhResponse(payload)
 	case ErrorResponseCode:
 		return nil, parseErrorResponse(payload)
 	default:
@@ -247,6 +253,12 @@ func parseGetPubKeyResponse(payload []byte) (Response, error) {
 func parseEchoResponse(payload []byte) (Response, error) {
 	return &EchoResponse{
 		Data: payload,
+	}, nil
+}
+
+func parseDeriveEcdhResponse(payload []byte) (Response, error) {
+	return &DeriveEcdhResponse{
+		XCoordinate: payload,
 	}, nil
 }
 

--- a/commands/types.go
+++ b/commands/types.go
@@ -42,7 +42,8 @@ const (
 	CommandTypeGetPubKey             CommandType = 0x54
 	CommandTypeSignDataPss           CommandType = 0x55
 	CommandTypeSignDataEcdsa         CommandType = 0x56
-	CommandTypeDecryptEcdh           CommandType = 0x57
+	CommandTypeDecryptEcdh           CommandType = 0x57 // here for backwards compatibility
+	CommandTypeDeriveEcdh            CommandType = 0x57
 	CommandTypeDeleteObject          CommandType = 0x58
 	CommandTypeDecryptOaep           CommandType = 0x59
 	CommandTypeGenerateHMACKey       CommandType = 0x5a
@@ -94,7 +95,8 @@ const (
 	CapabilityAsymmetricSignEddsa   uint64 = 0x0000000000000100
 	CapabilityAsymmetricDecryptPkcs uint64 = 0x0000000000000200
 	CapabilityAsymmetricDecryptOaep uint64 = 0x0000000000000400
-	CapabilityAsymmetricDecryptEcdh uint64 = 0x0000000000000800
+	CapabilityAsymmetricDecryptEcdh uint64 = 0x0000000000000800 // here for backwards compatibility
+	CapabilityAsymmetricDeriveEcdh  uint64 = 0x0000000000000800
 	CapabilityExportWrapped         uint64 = 0x0000000000001000
 	CapabilityImportWrapped         uint64 = 0x0000000000002000
 	CapabilityPutWrapKey            uint64 = 0x0000000000004000


### PR DESCRIPTION
Add the implementation fo the DeriveEcdh command alongside a command
name that matches what Yubi calls it.

Left the previously named one alone so this doesn't break backwards
compatibility if anyone was using that.

Docs: https://developers.yubico.com/YubiHSM2/Commands/Derive_Ecdh.html