### PR TITLE
Add commands, better conform with yubiHSM docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Currently the following commands are implemented:
  * Reset
  * GenerateAsymmetricKey
  * SignDataEddsa
+ * SignDataPkcs1
  * PutAsymmetricKey
  * GetPubKey
  * DeriveEcdh
@@ -17,9 +18,9 @@ Currently the following commands are implemented:
  * PutAuthenticationKey
  * GetOpaque
  * PutOpaque
- * SignDataPkcs1
  * SignAttestationCertificate
  * Authentication & Session related commands
+ * GetPseudoRandom
 
 Implementing new commands is really easy. Please consult `commands/constructors.go` and `commands/response.go` for reference.
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,17 @@ Currently the following commands are implemented:
  * Reset
  * GenerateAsymmetricKey
  * SignDataEddsa
- * SignDataPkcs1
  * PutAsymmetricKey
  * GetPubKey
  * DeriveEcdh
  * Echo
  * ChangeAuthenticationKey
+ * PutAuthenticationKey
+ * GetOpaque
+ * PutOpaque
+ * SignDataPkcs1
+ * SignAttestationCertificate
  * Authentication & Session related commands
- * GetPseudoRandom
 
 Implementing new commands is really easy. Please consult `commands/constructors.go` and `commands/response.go` for reference.
 

--- a/commands/constructors.go
+++ b/commands/constructors.go
@@ -94,20 +94,6 @@ func CreateSignDataEcdsaCommand(keyID uint16, data []byte) (*CommandMessage, err
 	return command, nil
 }
 
-func CreateSignDataPkcs1Command(keyID uint16, data []byte) (*CommandMessage, error) {
-	command := &CommandMessage{
-		CommandType: CommandTypeSignDataPkcs1,
-	}
-
-	payload := bytes.NewBuffer([]byte{})
-	binary.Write(payload, binary.BigEndian, keyID)
-	payload.Write(data)
-
-	command.Data = payload.Bytes()
-
-	return command, nil
-}
-
 func CreatePutAsymmetricKeyCommand(keyID uint16, label []byte, domains uint16, capabilities uint64, algorithm Algorithm, keyPart1 []byte, keyPart2 []byte) (*CommandMessage, error) {
 	if len(label) > LabelLength {
 		return nil, errors.New("label is too long")
@@ -149,6 +135,26 @@ func NewIDOption(id uint16) ListCommandOption {
 		binary.Write(w, binary.BigEndian, ListObjectParamID)
 		binary.Write(w, binary.BigEndian, id)
 	}
+}
+
+func NewDomainOption(domain uint16) ListCommandOption {
+	return func(w io.Writer) {
+		binary.Write(w, binary.BigEndian, ListObjectParamDomains)
+		binary.Write(w, binary.BigEndian, domain)
+	}
+}
+
+func NewLabelOption(label []byte) (ListCommandOption, error) {
+	if len(label) > LabelLength {
+		return nil, errors.New("label is too long")
+	}
+	if len(label) < LabelLength {
+		label = append(label, bytes.Repeat([]byte{0x00}, LabelLength-len(label))...)
+	}
+	return func(w io.Writer) {
+		binary.Write(w, binary.BigEndian, ListObjectParamLabel)
+		binary.Write(w, binary.BigEndian, label)
+	}, nil
 }
 
 func CreateListObjectsCommand(options ...ListCommandOption) (*CommandMessage, error) {
@@ -235,6 +241,33 @@ func CreateDeriveEcdhCommand(objID uint16, pubkey []byte) (*CommandMessage, erro
 	return command, nil
 }
 
+func CreatePutAuthenticationKeyCommand(objID uint16, label []byte, domains uint16, capabilities uint64, delegated uint64, password string) (*CommandMessage, error) {
+	if len(label) > LabelLength {
+		return nil, errors.New("label is too long")
+	}
+	if len(label) < LabelLength {
+		label = append(label, bytes.Repeat([]byte{0x00}, LabelLength-len(label))...)
+	}
+
+	command := &CommandMessage{
+		CommandType: CommandTypePutAuthKey,
+	}
+
+	authKey := authkey.NewFromPassword(password)
+	payload := bytes.NewBuffer([]byte{})
+	binary.Write(payload, binary.BigEndian, objID)
+	payload.Write(label)
+	binary.Write(payload, binary.BigEndian, domains)
+	binary.Write(payload, binary.BigEndian, capabilities)
+	binary.Write(payload, binary.BigEndian, AlgorithmYubicoAESAuthentication)
+	binary.Write(payload, binary.BigEndian, delegated)
+	payload.Write(authKey.GetEncKey())
+	payload.Write(authKey.GetMacKey())
+	command.Data = payload.Bytes()
+
+	return command, nil
+}
+
 func CreateChangeAuthenticationKeyCommand(objID uint16, newPassword string) (*CommandMessage, error) {
 	command := &CommandMessage{
 		CommandType: CommandTypeChangeAuthenticationKey,
@@ -251,90 +284,65 @@ func CreateChangeAuthenticationKeyCommand(objID uint16, newPassword string) (*Co
 	return command, nil
 }
 
-func CreateGetPseudoRandomCommand(numBytes uint16) *CommandMessage {
-	command := &CommandMessage{
-		CommandType: CommandTypeGetPseudoRandom,
-	}
-
-	payload := bytes.NewBuffer([]byte{})
-	binary.Write(payload, binary.BigEndian, numBytes)
-	command.Data = payload.Bytes()
-
-	return command
-}
-
-func CreatePutWrapkeyCommand(objID uint16, label []byte, domains uint16, capabilities uint64, algorithm Algorithm, delegated uint64, wrapkey []byte) (*CommandMessage, error) {
+func CreatePutOpaqueCommand(objID uint16, label []byte, domains uint16, capabilities uint64, algorithm Algorithm, data []byte) (*CommandMessage, error) {
 	if len(label) > LabelLength {
 		return nil, errors.New("label is too long")
 	}
 	if len(label) < LabelLength {
 		label = append(label, bytes.Repeat([]byte{0x00}, LabelLength-len(label))...)
 	}
-	switch algorithm {
-	case AlgorithmAES128CCMWrap:
-		if keyLen := len(wrapkey); keyLen != 16 {
-			return nil, errors.New("wrapkey is wrong length")
-		}
-	case AlgorithmAES192CCMWrap:
-		if keyLen := len(wrapkey); keyLen != 24 {
-			return nil, errors.New("wrapkey is wrong length")
-		}
-	case AlgorithmAES256CCMWrap:
-		if keyLen := len(wrapkey); keyLen != 32 {
-			return nil, errors.New("wrapkey is wrong length")
-		}
-	default:
-		return nil, errors.New("invalid algorithm")
-	}
 
 	command := &CommandMessage{
-		CommandType: CommandTypePutWrapKey,
+		CommandType: CommandTypePutOpaque,
 	}
 
-	payload := bytes.NewBuffer([]byte{})
+	payload := bytes.NewBuffer(nil)
 	binary.Write(payload, binary.BigEndian, objID)
 	payload.Write(label)
 	binary.Write(payload, binary.BigEndian, domains)
 	binary.Write(payload, binary.BigEndian, capabilities)
 	binary.Write(payload, binary.BigEndian, algorithm)
-	binary.Write(payload, binary.BigEndian, delegated)
-	payload.Write(wrapkey)
+	payload.Write(data)
 
 	command.Data = payload.Bytes()
 
 	return command, nil
 }
 
-func CreatePutAuthkeyCommand(objID uint16, label []byte, domains uint16, capabilities, delegated uint64, encKey, macKey []byte) (*CommandMessage, error) {
-	if len(label) > LabelLength {
-		return nil, errors.New("label is too long")
-	}
-	if len(label) < LabelLength {
-		label = append(label, bytes.Repeat([]byte{0x00}, LabelLength-len(label))...)
-	}
-	algorithm := AlgorithmYubicoAESAuthentication
-	// TODO: support P256 Authentication when it is released
-	// https://github.com/Yubico/yubihsm-shell/blob/1c8e254603e72f3f39cf1c3910996dbfcdba2b12/lib/yubihsm.c#L3110
-	if len(encKey) != 16 {
-		return nil, errors.New("invalid encryption key length")
-	}
-	if len(macKey) != 16 {
-		return nil, errors.New("invalid mac key length")
+func CreateGetOpaqueCommand(objID uint16) (*CommandMessage, error) {
+	command := &CommandMessage{
+		CommandType: CommandTypeGetOpaque,
 	}
 
+	payload := bytes.NewBuffer(nil)
+	binary.Write(payload, binary.BigEndian, objID)
+	command.Data = payload.Bytes()
+
+	return command, nil
+}
+
+func CreateSignDataPkcs1Command(objID uint16, data []byte) (*CommandMessage, error) {
 	command := &CommandMessage{
-		CommandType: CommandTypePutAuthKey,
+		CommandType: CommandTypeSignDataPkcs1,
 	}
 
 	payload := bytes.NewBuffer([]byte{})
 	binary.Write(payload, binary.BigEndian, objID)
-	payload.Write(label)
-	binary.Write(payload, binary.BigEndian, domains)
-	binary.Write(payload, binary.BigEndian, capabilities)
-	binary.Write(payload, binary.BigEndian, algorithm)
-	binary.Write(payload, binary.BigEndian, delegated)
-	payload.Write(encKey)
-	payload.Write(macKey)
+	payload.Write(data)
+
+	command.Data = payload.Bytes()
+
+	return command, nil
+}
+
+func CreateSignAttestationCertCommand(keyObjID, attestationObjID uint16) (*CommandMessage, error) {
+	command := &CommandMessage{
+		CommandType: CommandTypeAttestAsymmetric,
+	}
+
+	payload := bytes.NewBuffer([]byte{})
+	binary.Write(payload, binary.BigEndian, keyObjID)
+	binary.Write(payload, binary.BigEndian, attestationObjID)
 
 	command.Data = payload.Bytes()
 

--- a/commands/constructors.go
+++ b/commands/constructors.go
@@ -362,7 +362,7 @@ func CreatePutWrapkeyCommand(objID uint16, label []byte, domains uint16, capabil
 	return command, nil
 }
 
-func CreatePutAuthenticationKeyCommand(objID uint16, label []byte, domains uint16, capabilities, delegated uint64, encKey, macKey []byte) (*CommandMessage, error) {
+func CreatePutAuthkeyCommand(objID uint16, label []byte, domains uint16, capabilities, delegated uint64, encKey, macKey []byte) (*CommandMessage, error) {
 	if len(label) > LabelLength {
 		return nil, errors.New("label is too long")
 	}
@@ -380,7 +380,7 @@ func CreatePutAuthenticationKeyCommand(objID uint16, label []byte, domains uint1
 	}
 
 	command := &CommandMessage{
-		CommandType: CommandTypePutAuthenticationKey,
+		CommandType: CommandTypePutAuthKey,
 	}
 
 	payload := bytes.NewBuffer([]byte{})
@@ -400,7 +400,7 @@ func CreatePutAuthenticationKeyCommand(objID uint16, label []byte, domains uint1
 
 func CreatePutDerivedAuthenticationKeyCommand(objID uint16, label []byte, domains uint16, capabilities uint64, delegated uint64, password string) (*CommandMessage, error) {
 	authKey := authkey.NewFromPassword(password)
-	return CreatePutAuthenticationKeyCommand(objID, label, domains, capabilities, delegated, authKey.GetEncKey(), authKey.GetMacKey())
+	return CreatePutAuthkeyCommand(objID, label, domains, capabilities, delegated, authKey.GetEncKey(), authKey.GetMacKey())
 }
 
 func CreateSignAttestationCertCommand(keyObjID, attestationObjID uint16) (*CommandMessage, error) {

--- a/commands/response.go
+++ b/commands/response.go
@@ -92,7 +92,7 @@ type (
 		ObjectID uint16
 	}
 
-	PutAuthenticationKeyResponse struct {
+	PutAuthkeyResponse struct {
 		ObjectID uint16
 	}
 
@@ -167,8 +167,8 @@ func ParseResponse(data []byte) (Response, error) {
 		return parseGetPseudoRandomResponse(payload), nil
 	case CommandTypePutWrapKey:
 		return parsePutWrapkeyResponse(payload)
-	case CommandTypePutAuthenticationKey:
-		return parsePutAuthenticationKeyResponse(payload)
+	case CommandTypePutAuthKey:
+		return parsePutAuthkeyResponse(payload)
 	case CommandTypePutOpaque:
 		return parsePutOpaqueResponse(payload)
 	case CommandTypeGetOpaque:
@@ -347,7 +347,7 @@ func parsePutWrapkeyResponse(payload []byte) (Response, error) {
 	return &PutWrapkeyResponse{ObjectID: objectID}, nil
 }
 
-func parsePutAuthenticationKeyResponse(payload []byte) (Response, error) {
+func parsePutAuthkeyResponse(payload []byte) (Response, error) {
 	if len(payload) != 2 {
 		return nil, errors.New("invalid response payload length")
 	}
@@ -358,7 +358,7 @@ func parsePutAuthenticationKeyResponse(payload []byte) (Response, error) {
 		return nil, err
 	}
 
-	return &PutAuthenticationKeyResponse{ObjectID: objectID}, nil
+	return &PutAuthkeyResponse{ObjectID: objectID}, nil
 }
 
 func parsePutOpaqueResponse(payload []byte) (Response, error) {

--- a/commands/types.go
+++ b/commands/types.go
@@ -23,7 +23,7 @@ const (
 	CommandTypeStorageStatus           CommandType = 0x41
 	CommandTypePutOpaque               CommandType = 0x42
 	CommandTypeGetOpaque               CommandType = 0x43
-	CommandTypePutAuthKey              CommandType = 0x44
+	CommandTypePutAuthenticationKey    CommandType = 0x44
 	CommandTypePutAsymmetric           CommandType = 0x45
 	CommandTypeGenerateAsymmetricKey   CommandType = 0x46
 	CommandTypeSignDataPkcs1           CommandType = 0x47
@@ -64,23 +64,24 @@ const (
 	CommandTypeChangeAuthenticationKey CommandType = 0x6c
 
 	// Errors
-	ErrorCodeOK                         ErrorCode = 0x00
-	ErrorCodeInvalidCommand             ErrorCode = 0x01
-	ErrorCodeInvalidData                ErrorCode = 0x02
-	ErrorCodeInvalidSession             ErrorCode = 0x03
-	ErrorCodeAuthFail                   ErrorCode = 0x04
-	ErrorCodeSessionFull                ErrorCode = 0x05
-	ErrorCodeSessionFailed              ErrorCode = 0x06
-	ErrorCodeStorageFailed              ErrorCode = 0x07
-	ErrorCodeWrongLength                ErrorCode = 0x08
-	ErrorCodeInvalidPermission          ErrorCode = 0x09
-	ErrorCodeLogFull                    ErrorCode = 0x0a
-	ErrorCodeObjectNotFound             ErrorCode = 0x0b
-	ErrorCodeInvalidID                  ErrorCode = 0x0c
-	ErrorCodeSSHCAConstraintViolation   ErrorCode = 0x0e
-	ErrorCodeInvalidOTP                 ErrorCode = 0x0f
-	ErrorCodeDemoMode                   ErrorCode = 0x10
-	ErrorCodeObjectExists               ErrorCode = 0x11
+	ErrorCodeOK                       ErrorCode = 0x00
+	ErrorCodeInvalidCommand           ErrorCode = 0x01
+	ErrorCodeInvalidData              ErrorCode = 0x02
+	ErrorCodeInvalidSession           ErrorCode = 0x03
+	ErrorCodeAuthFail                 ErrorCode = 0x04
+	ErrorCodeSessionFull              ErrorCode = 0x05
+	ErrorCodeSessionFailed            ErrorCode = 0x06
+	ErrorCodeStorageFailed            ErrorCode = 0x07
+	ErrorCodeWrongLength              ErrorCode = 0x08
+	ErrorCodeInvalidPermission        ErrorCode = 0x09
+	ErrorCodeLogFull                  ErrorCode = 0x0a
+	ErrorCodeObjectNotFound           ErrorCode = 0x0b
+	ErrorCodeInvalidID                ErrorCode = 0x0c
+	ErrorCodeSSHCAConstraintViolation ErrorCode = 0x0e
+	ErrorCodeInvalidOTP               ErrorCode = 0x0f
+	ErrorCodeDemoMode                 ErrorCode = 0x10
+	ErrorCodeObjectExists             ErrorCode = 0x11
+	ErrorCodeCommandUnexecuted        ErrorCode = 0xff
 
 	// Algorithms
 	AlgorithmRSA2048                 Algorithm = 9
@@ -89,58 +90,61 @@ const (
 	AlgorithmOpaqueData              Algorithm = 30
 	AlgorithmOpaqueX509Certificate   Algorithm = 31
 	AlgorithmYubicoAESAuthentication Algorithm = 38
+	AlgorithmAES128CCMWrap           Algorithm = 29
+	AlgorithmAES192CCMWrap           Algorithm = 41
+	AlgorithmAES256CCMWrap           Algorithm = 42
 	AlgorithmED25519                 Algorithm = 46
 
 	// Capabilities
-	CapabilityNone                  uint64 = 0x0000000000000000
-	CapabilityGetOpaque             uint64 = 0x0000000000000001
-	CapabilityPutOpaque             uint64 = 0x0000000000000002
-	CapabilityPutAuthKey            uint64 = 0x0000000000000004
-	CapabilityPutAsymmetric         uint64 = 0x0000000000000008
-	CapabilityAsymmetricGen         uint64 = 0x0000000000000010
-	CapabilityAsymmetricSignPkcs    uint64 = 0x0000000000000020
-	CapabilityAsymmetricSignPss     uint64 = 0x0000000000000040
-	CapabilityAsymmetricSignEcdsa   uint64 = 0x0000000000000080
-	CapabilityAsymmetricSignEddsa   uint64 = 0x0000000000000100
-	CapabilityAsymmetricDecryptPkcs uint64 = 0x0000000000000200
-	CapabilityAsymmetricDecryptOaep uint64 = 0x0000000000000400
-	CapabilityAsymmetricDecryptEcdh uint64 = 0x0000000000000800 // here for backwards compatibility
-	CapabilityAsymmetricDeriveEcdh  uint64 = 0x0000000000000800
-	CapabilityExportWrapped         uint64 = 0x0000000000001000
-	CapabilityImportWrapped         uint64 = 0x0000000000002000
-	CapabilityPutWrapKey            uint64 = 0x0000000000004000
-	CapabilityGenerateWrapKey       uint64 = 0x0000000000008000
-	CapabilityExportableUnderWrap   uint64 = 0x0000000000010000
-	CapabilityPutOption             uint64 = 0x0000000000020000
-	CapabilityGetOption             uint64 = 0x0000000000040000
-	CapabilityGetRandomness         uint64 = 0x0000000000080000
-	CapabilityPutHmacKey            uint64 = 0x0000000000100000
-	CapabilityHmacKeyGenerate       uint64 = 0x0000000000200000
-	CapabilityHmacData              uint64 = 0x0000000000400000
-	CapabilityHmacVerify            uint64 = 0x0000000000800000
-	CapabilityAudit                 uint64 = 0x0000000001000000
-	CapabilitySshCertify            uint64 = 0x0000000002000000
-	CapabilityGetTemplate           uint64 = 0x0000000004000000
-	CapabilityPutTemplate           uint64 = 0x0000000008000000
-	CapabilityReset                 uint64 = 0x0000000010000000
-	CapabilityOtpDecrypt            uint64 = 0x0000000020000000
-	CapabilityOtpAeadCreate         uint64 = 0x0000000040000000
-	CapabilityOtpAeadRandom         uint64 = 0x0000000080000000
-	CapabilityOtpAeadRewrapFrom     uint64 = 0x0000000100000000
-	CapabilityOtpAeadRewrapTo       uint64 = 0x0000000200000000
-	CapabilityAttest                uint64 = 0x0000000400000000
-	CapabilityPutOtpAeadKey         uint64 = 0x0000000800000000
-	CapabilityGenerateOtpAeadKey    uint64 = 0x0000001000000000
-	CapabilityWrapData              uint64 = 0x0000002000000000
-	CapabilityUnwrapData            uint64 = 0x0000004000000000
-	CapabilityDeleteOpaque          uint64 = 0x0000008000000000
-	CapabilityDeleteAuthKey         uint64 = 0x0000010000000000
-	CapabilityDeleteAsymmetric      uint64 = 0x0000020000000000
-	CapabilityDeleteWrapKey         uint64 = 0x0000040000000000
-	CapabilityDeleteHmacKey         uint64 = 0x0000080000000000
-	CapabilityDeleteTemplate        uint64 = 0x0000100000000000
-	CapabilityDeleteOtpAeadKey      uint64 = 0x0000200000000000
-	CapabilityChangeAuthKey         uint64 = 0x0000400000000000
+	CapabilityNone                    uint64 = 0x0000000000000000
+	CapabilityGetOpaque               uint64 = 0x0000000000000001
+	CapabilityPutOpaque               uint64 = 0x0000000000000002
+	CapabilityPutAuthenticationKey    uint64 = 0x0000000000000004
+	CapabilityPutAsymmetric           uint64 = 0x0000000000000008
+	CapabilityAsymmetricGen           uint64 = 0x0000000000000010
+	CapabilityAsymmetricSignPkcs      uint64 = 0x0000000000000020
+	CapabilityAsymmetricSignPss       uint64 = 0x0000000000000040
+	CapabilityAsymmetricSignEcdsa     uint64 = 0x0000000000000080
+	CapabilityAsymmetricSignEddsa     uint64 = 0x0000000000000100
+	CapabilityAsymmetricDecryptPkcs   uint64 = 0x0000000000000200
+	CapabilityAsymmetricDecryptOaep   uint64 = 0x0000000000000400
+	CapabilityAsymmetricDecryptEcdh   uint64 = 0x0000000000000800 // here for backwards compatibility
+	CapabilityAsymmetricDeriveEcdh    uint64 = 0x0000000000000800
+	CapabilityExportWrapped           uint64 = 0x0000000000001000
+	CapabilityImportWrapped           uint64 = 0x0000000000002000
+	CapabilityPutWrapKey              uint64 = 0x0000000000004000
+	CapabilityGenerateWrapKey         uint64 = 0x0000000000008000
+	CapabilityExportableUnderWrap     uint64 = 0x0000000000010000
+	CapabilityPutOption               uint64 = 0x0000000000020000
+	CapabilityGetOption               uint64 = 0x0000000000040000
+	CapabilityGetRandomness           uint64 = 0x0000000000080000
+	CapabilityPutHmacKey              uint64 = 0x0000000000100000
+	CapabilityHmacKeyGenerate         uint64 = 0x0000000000200000
+	CapabilityHmacData                uint64 = 0x0000000000400000
+	CapabilityHmacVerify              uint64 = 0x0000000000800000
+	CapabilityAudit                   uint64 = 0x0000000001000000
+	CapabilitySshCertify              uint64 = 0x0000000002000000
+	CapabilityGetTemplate             uint64 = 0x0000000004000000
+	CapabilityPutTemplate             uint64 = 0x0000000008000000
+	CapabilityReset                   uint64 = 0x0000000010000000
+	CapabilityOtpDecrypt              uint64 = 0x0000000020000000
+	CapabilityOtpAeadCreate           uint64 = 0x0000000040000000
+	CapabilityOtpAeadRandom           uint64 = 0x0000000080000000
+	CapabilityOtpAeadRewrapFrom       uint64 = 0x0000000100000000
+	CapabilityOtpAeadRewrapTo         uint64 = 0x0000000200000000
+	CapabilityAttest                  uint64 = 0x0000000400000000
+	CapabilityPutOtpAeadKey           uint64 = 0x0000000800000000
+	CapabilityGenerateOtpAeadKey      uint64 = 0x0000001000000000
+	CapabilityWrapData                uint64 = 0x0000002000000000
+	CapabilityUnwrapData              uint64 = 0x0000004000000000
+	CapabilityDeleteOpaque            uint64 = 0x0000008000000000
+	CapabilityDeleteAuthKey           uint64 = 0x0000010000000000
+	CapabilityDeleteAsymmetric        uint64 = 0x0000020000000000
+	CapabilityDeleteWrapKey           uint64 = 0x0000040000000000
+	CapabilityDeleteHmacKey           uint64 = 0x0000080000000000
+	CapabilityDeleteTemplate          uint64 = 0x0000100000000000
+	CapabilityDeleteOtpAeadKey        uint64 = 0x0000200000000000
+	CapabilityChangeAuthenticationKey uint64 = 0x0000400000000000
 
 	// Domains
 	Domain1  uint16 = 0x0001
@@ -170,10 +174,19 @@ const (
 	ObjectTypeOtpAeadKey        uint8 = 0x07
 
 	// list objects params
-	ListObjectParamID   		uint8 = 0x01
-	ListObjectParamType 		uint8 = 0x02
-	ListObjectParamDomains   	uint8 = 0x03
-	ListObjectParamCapabilities	uint8 = 0x04
-	ListObjectParamAlgorithm   	uint8 = 0x05
-	ListObjectParamLabel 		uint8 = 0x06
+	ListObjectParamID           uint8 = 0x01
+	ListObjectParamType         uint8 = 0x02
+	ListObjectParamDomains      uint8 = 0x03
+	ListObjectParamCapabilities uint8 = 0x04
+	ListObjectParamAlgorithm    uint8 = 0x05
+	ListObjectParamLabel        uint8 = 0x06
 )
+
+// CapabilityPrimitiveFromSlice OR's all the capabilitites together.
+func CapabilityPrimitiveFromSlice(capabilitites []uint64) uint64 {
+	var primitive uint64
+	for _, c := range capabilitites {
+		primitive |= c
+	}
+	return primitive
+}

--- a/commands/types.go
+++ b/commands/types.go
@@ -23,7 +23,7 @@ const (
 	CommandTypeStorageStatus           CommandType = 0x41
 	CommandTypePutOpaque               CommandType = 0x42
 	CommandTypeGetOpaque               CommandType = 0x43
-	CommandTypePutAuthenticationKey    CommandType = 0x44
+	CommandTypePutAuthKey              CommandType = 0x44
 	CommandTypePutAsymmetric           CommandType = 0x45
 	CommandTypeGenerateAsymmetricKey   CommandType = 0x46
 	CommandTypeSignDataPkcs1           CommandType = 0x47

--- a/commands/types.go
+++ b/commands/types.go
@@ -64,31 +64,35 @@ const (
 	CommandTypeChangeAuthenticationKey CommandType = 0x6c
 
 	// Errors
-	ErrorCodeOK                ErrorCode = 0x00
-	ErrorCodeInvalidCommand    ErrorCode = 0x01
-	ErrorCodeInvalidData       ErrorCode = 0x02
-	ErrorCodeInvalidSession    ErrorCode = 0x03
-	ErrorCodeAuthFail          ErrorCode = 0x04
-	ErrorCodeSessionFull       ErrorCode = 0x05
-	ErrorCodeSessionFailed     ErrorCode = 0x06
-	ErrorCodeStorageFailed     ErrorCode = 0x07
-	ErrorCodeWrongLength       ErrorCode = 0x08
-	ErrorCodeInvalidPermission ErrorCode = 0x09
-	ErrorCodeLogFull           ErrorCode = 0x0a
-	ErrorCodeObjectNotFound    ErrorCode = 0x0b
-	ErrorCodeIDIllegal         ErrorCode = 0x0c
-	ErrorCodeCommandUnexecuted ErrorCode = 0xff
+	ErrorCodeOK                         ErrorCode = 0x00
+	ErrorCodeInvalidCommand             ErrorCode = 0x01
+	ErrorCodeInvalidData                ErrorCode = 0x02
+	ErrorCodeInvalidSession             ErrorCode = 0x03
+	ErrorCodeAuthFail                   ErrorCode = 0x04
+	ErrorCodeSessionFull                ErrorCode = 0x05
+	ErrorCodeSessionFailed              ErrorCode = 0x06
+	ErrorCodeStorageFailed              ErrorCode = 0x07
+	ErrorCodeWrongLength                ErrorCode = 0x08
+	ErrorCodeInvalidPermission          ErrorCode = 0x09
+	ErrorCodeLogFull                    ErrorCode = 0x0a
+	ErrorCodeObjectNotFound             ErrorCode = 0x0b
+	ErrorCodeInvalidID                  ErrorCode = 0x0c
+	ErrorCodeSSHCAConstraintViolation   ErrorCode = 0x0e
+	ErrorCodeInvalidOTP                 ErrorCode = 0x0f
+	ErrorCodeDemoMode                   ErrorCode = 0x10
+	ErrorCodeObjectExists               ErrorCode = 0x11
 
 	// Algorithms
+	AlgorithmRSA2048                 Algorithm = 9
 	AlgorithmP256                    Algorithm = 12
 	AlgorithmSecp256k1               Algorithm = 15
+	AlgorithmOpaqueData              Algorithm = 30
+	AlgorithmOpaqueX509Certificate   Algorithm = 31
 	AlgorithmYubicoAESAuthentication Algorithm = 38
-	AlgorighmED25519                 Algorithm = 46
-	AlgorithmAES128CCMWrap           Algorithm = 29
-	AlgorithmAES192CCMWrap           Algorithm = 41
-	AlgorithmAES256CCMWrap           Algorithm = 42
+	AlgorithmED25519                 Algorithm = 46
 
 	// Capabilities
+	CapabilityNone                  uint64 = 0x0000000000000000
 	CapabilityGetOpaque             uint64 = 0x0000000000000001
 	CapabilityPutOpaque             uint64 = 0x0000000000000002
 	CapabilityPutAuthKey            uint64 = 0x0000000000000004
@@ -106,7 +110,7 @@ const (
 	CapabilityImportWrapped         uint64 = 0x0000000000002000
 	CapabilityPutWrapKey            uint64 = 0x0000000000004000
 	CapabilityGenerateWrapKey       uint64 = 0x0000000000008000
-	CapabilityExportUnderWrap       uint64 = 0x0000000000010000
+	CapabilityExportableUnderWrap   uint64 = 0x0000000000010000
 	CapabilityPutOption             uint64 = 0x0000000000020000
 	CapabilityGetOption             uint64 = 0x0000000000040000
 	CapabilityGetRandomness         uint64 = 0x0000000000080000
@@ -136,6 +140,7 @@ const (
 	CapabilityDeleteHmacKey         uint64 = 0x0000080000000000
 	CapabilityDeleteTemplate        uint64 = 0x0000100000000000
 	CapabilityDeleteOtpAeadKey      uint64 = 0x0000200000000000
+	CapabilityChangeAuthKey         uint64 = 0x0000400000000000
 
 	// Domains
 	Domain1  uint16 = 0x0001
@@ -165,15 +170,10 @@ const (
 	ObjectTypeOtpAeadKey        uint8 = 0x07
 
 	// list objects params
-	ListObjectParamID   uint8 = 0x01
-	ListObjectParamType uint8 = 0x02
+	ListObjectParamID   		uint8 = 0x01
+	ListObjectParamType 		uint8 = 0x02
+	ListObjectParamDomains   	uint8 = 0x03
+	ListObjectParamCapabilities	uint8 = 0x04
+	ListObjectParamAlgorithm   	uint8 = 0x05
+	ListObjectParamLabel 		uint8 = 0x06
 )
-
-// CapabilityPrimitiveFromSlice OR's all the capabilitites together.
-func CapabilityPrimitiveFromSlice(capabilitites []uint64) uint64 {
-	var primitive uint64
-	for _, c := range capabilitites {
-		primitive |= c
-	}
-	return primitive
-}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/certusone/yubihsm-go
 
+go 1.14
+
 require (
 	github.com/enceve/crypto v0.0.0-20160707101852-34d48bb93815
-	golang.org/x/crypto v0.0.0-20180830192347-182538f80094
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,10 @@ github.com/enceve/crypto v0.0.0-20160707101852-34d48bb93815 h1:D22EM5TeYZJp43hGD
 github.com/enceve/crypto v0.0.0-20160707101852-34d48bb93815/go.mod h1:wYFFK4LYXbX7j+76mOq7aiC/EAw2S22CrzPHqgsisPw=
 golang.org/x/crypto v0.0.0-20180830192347-182538f80094 h1:rVTAlhYa4+lCfNxmAIEOGQRoD23UqP72M3+rSWVGDTg=
 golang.org/x/crypto v0.0.0-20180830192347-182538f80094/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/securechannel/channel.go
+++ b/securechannel/channel.go
@@ -85,6 +85,8 @@ const (
 	MaxMessagesPerSession = 10000
 )
 
+var ErrAuthCryptogram = errors.New("authentication failed: device sent wrong cryptogram")
+
 // NewSecureChannel initiates a new secure channel to communicate with an HSM using the given authKey
 // Call Authenticate next to establish a session.
 func NewSecureChannel(connector connector.Connector, authKeySlot uint16, password string) (*SecureChannel, error) {
@@ -143,7 +145,7 @@ func (s *SecureChannel) Authenticate() error {
 	}
 
 	if !bytes.Equal(deviceCryptogram, createSessionResp.CardCryptogram) {
-		return errors.New("authentication failed: device sent wrong cryptogram")
+		return ErrAuthCryptogram
 	}
 
 	// Create host cryptogram


### PR DESCRIPTION
Added the following commands:
- `PutDerivedAuthenticationKey` (same as `PutAuthenticationKey` except it derives relevant keys from password)
- `GetOpaque`
- `PutOpaque`
- `SignAttestationCertificate`

Added more options/filters for `ListObjects` and some algorithms & error codes

Also fixed some typos and standardized naming to better conform with the yubiHSM docs
