### PR TITLE
Connector: check len(values) to avoid nil pointer dereference

### DIFF
--- a/connector/http.go
+++ b/connector/http.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -9,6 +10,8 @@ import (
 
 	"github.com/certusone/yubihsm-go/commands"
 )
+
+var ErrInvalidResponseValueLength = errors.New("invalid response value length")
 
 type (
 	// HTTPConnector implements the HTTP based connection with the YubiHSM2 connector
@@ -66,8 +69,12 @@ func (c *HTTPConnector) GetStatus() (*StatusResponse, error) {
 	for _, pair := range pairs {
 		values = append(values, strings.Split(pair, "=")...)
 	}
-
 	status := &StatusResponse{}
+
+	if values == nil || len(values) < 12 {
+		return nil, ErrInvalidResponseValueLength
+	}
+
 	status.Status = Status(values[1])
 	status.Serial = values[3]
 	status.Version = values[5]


### PR DESCRIPTION
Do a len() check on values otherwise we could panic out here:

```go
	status.Status = Status(values[1])
	status.Serial = values[3]
	status.Version = values[5]
	status.Pid = values[7]
	status.Address = values[9]
	status.Port = values[11]
```
https://github.com/yunginnanet/yubihsm-go/blob/995af3b2fdb55ee1eb1d21e54f5278cac19b2fa8/connector/http.go#L78-L83

This package not only needs test cases but probably some fuzzing as well. I'll do what I can.